### PR TITLE
Altcha verification middleware, per-call logging, and bun tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,5 @@ jobs:
         run: bun run format:check
       - name: Type-check (tsc)
         run: bun run typecheck
+      - name: Test (bun test)
+        run: bun test

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ service** (_Notfall-Hilfe Aufenthaltstitel_) every 5 minutes; use the manual
 
 `libs/` holds importable modules, `apps/` holds runnable entry points:
 
-| File                        | Purpose                                                                |
-| --------------------------- | ---------------------------------------------------------------------- |
-| `libs/client.ts`            | `MunichTerminClient` — availability + automatic Altcha captcha solving |
-| `libs/catalog.generated.ts` | Full scraped list of services & offices (do not edit by hand)          |
-| `libs/catalog.ts`           | Derived `ServiceId`/`OfficeId` types + validation helpers              |
-| `libs/watchlist.ts`         | The services to poll — **type-checked against the catalog**            |
-| `apps/check.ts`             | Per-service checker the CI runs; notifies on availability              |
-| `apps/find-service.ts`      | Search the catalog for service/office IDs                              |
-| `apps/matrix.ts`            | Emits the watch-list as JSON for the CI matrix                         |
-| `apps/generate-catalog.ts`  | Re-scrapes `libs/catalog.generated.ts` from the live API               |
+| File                        | Purpose                                                           |
+| --------------------------- | ----------------------------------------------------------------- |
+| `libs/client.ts`            | `MunichTerminClient` — availability requests + per-call logging   |
+| `libs/middleware.ts`        | Injectable request middleware; the Altcha verification lives here |
+| `libs/catalog.generated.ts` | Full scraped list of services & offices (do not edit by hand)     |
+| `libs/catalog.ts`           | Derived `ServiceId`/`OfficeId` types + validation helpers         |
+| `libs/watchlist.ts`         | The services to poll — **type-checked against the catalog**       |
+| `libs/*.test.ts`            | `bun test` unit tests (catalog, middleware, client)               |
+| `apps/check.ts`             | Per-service checker the CI runs; notifies on availability         |
+| `apps/find-service.ts`      | Search the catalog for service/office IDs                         |
+| `apps/matrix.ts`            | Emits the watch-list as JSON for the CI matrix                    |
+| `apps/generate-catalog.ts`  | Re-scrapes `libs/catalog.generated.ts` from the live API          |
 
 ## Adding a service to the watch-list
 
@@ -78,23 +80,33 @@ to pick `all` or a single service. The dropdown options live in the workflow
 ## Captcha-gated services (immigration)
 
 High-demand services (e.g. _Notfall-Hilfe Aufenthaltstitel_) are protected by an
-**Altcha** proof-of-work captcha. The client solves it automatically via the
-public `captcha-challenge` / `captcha-verify` endpoints (solve the proof-of-work,
-exchange it for a token, pass that to `available-days`) — **this works from
-anywhere, no proxy or German egress required.** Services marked `"captcha": true`
-in the watch-list are just documentation; detection is automatic.
+**Altcha** proof-of-work captcha. It is handled by an **injected middleware**
+([`libs/middleware.ts`](./libs/middleware.ts)) that activates only when a service
+answers `captchaMissing`: it solves the proof-of-work via the public
+`captcha-challenge` / `captcha-verify` endpoints, exchanges it for a token, and
+retries — **so it works from anywhere, no proxy or German egress required.**
+Keeping it as middleware keeps the captcha concern out of the core request path
+and makes it easy to swap or disable (`new MunichTerminClient({ middlewares: [] })`).
+Services marked `"captcha": true` in the watch-list are just documentation;
+detection is automatic.
 
 ## Develop
 
 ```bash
 bun install
+bun test                                            # bun's built-in test runner
 bun run typecheck                                   # tsc --noEmit (TypeScript 6)
 bun run format                                      # oxfmt --write .
 SERVICE_ID=1071896 OFFICE_ID=10308174 bun start     # check one service
+DEBUG=1 SERVICE_ID=10339028 OFFICE_ID=10461 bun start   # verbose run (immigration)
 ```
 
-- **CI** (`.github/workflows/ci.yml`) runs oxfmt + typecheck on every non-main
-  branch / PR.
+Every API call is logged (method, URL, status, timing, error body; the captcha
+token is redacted). The logger is injectable — `new MunichTerminClient({ logger: () => {} })`
+silences it.
+
+- **CI** (`.github/workflows/ci.yml`) runs oxfmt + typecheck + `bun test` on every
+  non-main branch / PR.
 - **Claude Code hooks** (`.claude/`) auto-run oxfmt + typecheck on each edit.
 
 Exit codes: `0` none free, `1` slot(s) found, `2` check error. Requires

--- a/apps/check.ts
+++ b/apps/check.ts
@@ -53,7 +53,7 @@ async function main(): Promise<void> {
   );
 
   const client = new MunichTerminClient();
-  const result = await client.availableDaysAuto({
+  const result = await client.availableDays({
     officeId,
     serviceId,
     serviceCount: SERVICE_COUNT,

--- a/libs/catalog.test.ts
+++ b/libs/catalog.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isOfficeId,
+  isServiceId,
+  officeName,
+  officesForService,
+  serviceName,
+  toOfficeId,
+  toServiceId,
+} from "./catalog";
+
+describe("catalog", () => {
+  it("validates service ids", () => {
+    expect(isServiceId(1071896)).toBe(true);
+    expect(isServiceId(99999999)).toBe(false);
+    expect(toServiceId(1071896)).toBe(1071896);
+    expect(() => toServiceId(99999999)).toThrow(/Unknown serviceId/);
+  });
+
+  it("validates office ids", () => {
+    expect(isOfficeId(10308174)).toBe(true);
+    expect(isOfficeId(99999999)).toBe(false);
+    expect(toOfficeId(10308174)).toBe(10308174);
+    expect(() => toOfficeId(99999999)).toThrow(/Unknown officeId/);
+  });
+
+  it("resolves names and offices", () => {
+    expect(serviceName(1071896)).toContain("Führerschein");
+    expect(officeName(10308174)).toContain("Führerscheinstelle");
+    expect(officesForService(1071896)).toContain(10308174);
+    expect(officesForService(10339028)).toContain(10461);
+  });
+});

--- a/libs/client.test.ts
+++ b/libs/client.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { type AvailableDaysQuery, MunichTerminClient } from "./client";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+type StubHandler = (url: string) => { status: number; body: unknown };
+function stubFetch(handler: StubHandler): void {
+  globalThis.fetch = (async (input: Request | string | URL) => {
+    const { status, body } = handler(String(input));
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+const baseQuery: AvailableDaysQuery = {
+  officeId: 10308174,
+  serviceId: 1071896,
+  startDate: "2026-06-01",
+  endDate: "2026-09-01",
+};
+
+describe("MunichTerminClient.availableDays", () => {
+  it("returns the available days", async () => {
+    stubFetch(() => ({ status: 200, body: { availableDays: ["2026-06-10", "2026-06-11"] } }));
+    const client = new MunichTerminClient({ logger: () => {} });
+    const result = await client.availableDays(baseQuery);
+    expect(result.days).toEqual(["2026-06-10", "2026-06-11"]);
+  });
+
+  it("treats noAppointmentForThisDay (404) as no slots", async () => {
+    stubFetch(() => ({
+      status: 404,
+      body: { errors: [{ errorCode: "noAppointmentForThisDay" }] },
+    }));
+    const client = new MunichTerminClient({ logger: () => {} });
+    const result = await client.availableDays(baseQuery);
+    expect(result.days).toEqual([]);
+  });
+
+  it("surfaces an unexpected error as days=null", async () => {
+    stubFetch(() => ({ status: 500, body: { errors: [{ errorCode: "serverError" }] } }));
+    const client = new MunichTerminClient({ logger: () => {} });
+    const result = await client.availableDays(baseQuery);
+    expect(result.days).toBeNull();
+    expect(result.errorCodes).toContain("serverError");
+  });
+
+  it("solves the Altcha captcha and retries when required", async () => {
+    const salt = "s4lt";
+    const challenge = createHash("sha256")
+      .update(salt + "0")
+      .digest("hex");
+    stubFetch((url) => {
+      if (url.includes("/captcha-challenge/")) {
+        return {
+          status: 200,
+          body: { algorithm: "SHA-256", challenge, salt, signature: "sig", maxnumber: 100 },
+        };
+      }
+      if (url.includes("/captcha-verify/")) {
+        return { status: 200, body: { token: "JWT-TEST", meta: { success: true } } };
+      }
+      if (url.includes("captchaToken=")) {
+        return { status: 200, body: { availableDays: ["2026-07-01"] } };
+      }
+      return { status: 400, body: { errors: [{ errorCode: "captchaMissing" }] } };
+    });
+    const client = new MunichTerminClient({ logger: () => {} });
+    const result = await client.availableDays(baseQuery);
+    expect(result.days).toEqual(["2026-07-01"]);
+  });
+
+  it("redacts the captcha token from logs", async () => {
+    stubFetch(() => ({ status: 200, body: { availableDays: [] } }));
+    const logs: string[] = [];
+    const client = new MunichTerminClient({ logger: (...a) => logs.push(a.map(String).join(" ")) });
+    await client.availableDays({ ...baseQuery, captchaToken: "SECRET-JWT" });
+    const joined = logs.join("\n");
+    expect(joined).toContain("captchaToken=<redacted>");
+    expect(joined).not.toContain("SECRET-JWT");
+  });
+});

--- a/libs/client.ts
+++ b/libs/client.ts
@@ -5,10 +5,12 @@
  * It can:
  *   - discover services + offices and their IDs (getServices / getOffices /
  *     getOfficesAndServices),
- *   - check available days for any service (getAvailableDays / availableDaysAuto),
+ *   - check available days for any service (availableDays),
  *   - transparently solve the Altcha proof-of-work captcha that gates the
  *     high-demand services (e.g. immigration / Aufenthaltstitel) via the public
  *     www48 challenge/verify endpoints — works from anywhere, no proxy needed.
+ *     Verification is an injected middleware (see middleware.ts); it activates
+ *     only for the services that actually demand it.
  *
  * An optional `proxy` (or MUC_PROXY_URL / HTTPS_PROXY) is still honoured if you
  * want to route requests through one, but it is not required.
@@ -16,14 +18,26 @@
 
 import { createHash } from "node:crypto";
 import type { OfficeId, ServiceId } from "./catalog";
+import {
+  altchaCaptchaMiddleware,
+  type AvailabilityHandler,
+  type AvailabilityMiddleware,
+} from "./middleware";
 
 export const DEFAULT_BASE: string =
   process.env.API_BASE || "https://www48.muenchen.de/buergeransicht/api/citizen";
+
+/** Structured logger; receives one log record per call. */
+export type Logger = (...args: unknown[]) => void;
 
 export interface ClientOptions {
   baseUrl?: string;
   proxy?: string;
   debug?: boolean;
+  /** API-call logger; defaults to stderr. Pass `() => {}` to silence. */
+  logger?: Logger;
+  /** Middlewares wrapping each availability request; defaults to Altcha verification. */
+  middlewares?: AvailabilityMiddleware[];
 }
 
 export interface Service {
@@ -106,24 +120,52 @@ export class MunichTerminClient {
   readonly baseUrl: string;
   readonly proxy: string | undefined;
   readonly debug: boolean;
+  readonly logger: Logger;
+  readonly middlewares: AvailabilityMiddleware[];
 
   constructor(options: ClientOptions = {}) {
     this.baseUrl = (options.baseUrl ?? DEFAULT_BASE).replace(/\/+$/, "");
     this.proxy = options.proxy ?? process.env.MUC_PROXY_URL ?? process.env.HTTPS_PROXY ?? undefined;
     this.debug = options.debug ?? !!process.env.DEBUG;
+    this.logger = options.logger ?? ((...args) => console.error("[muc]", ...args));
+    // Inject Altcha verification by default — it only activates when a service needs it.
+    this.middlewares = options.middlewares ?? [
+      altchaCaptchaMiddleware(() => this.solveCaptcha(), this.logger),
+    ];
   }
 
+  /** Verbose log, only when `debug` is on. */
   private log(...args: unknown[]): void {
-    if (this.debug) console.error("[client]", ...args);
+    if (this.debug) this.logger(...args);
   }
 
-  private fetch(url: string, opts: FetchInit = {}): Promise<Response> {
+  /** Hide the captcha JWT from logged URLs. */
+  private redact(url: string): string {
+    return url.replace(/(captchaToken=)[^&]+/, "$1<redacted>");
+  }
+
+  private async fetch(url: string, opts: FetchInit = {}): Promise<Response> {
     const init: FetchInit = {
       ...opts,
       headers: { Accept: "application/json", ...(opts.headers as Record<string, string>) },
     };
     if (this.proxy) init.proxy = this.proxy;
-    return fetch(url, init);
+
+    const method = init.method ?? "GET";
+    const safeUrl = this.redact(url);
+    const started = Date.now();
+    this.logger(`→ ${method} ${safeUrl}${this.proxy ? " (via proxy)" : ""}`);
+    try {
+      const res = await fetch(url, init);
+      this.logger(
+        `← ${res.status} ${res.statusText} ${method} ${safeUrl} (${Date.now() - started}ms)`,
+      );
+      return res;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger(`✖ ${method} ${safeUrl} failed after ${Date.now() - started}ms: ${message}`);
+      throw error;
+    }
   }
 
   private async json<T>(
@@ -132,6 +174,7 @@ export class MunichTerminClient {
   ): Promise<{ res: Response; body: Partial<T> }> {
     const res = await this.fetch(url, opts);
     const body = (await res.json().catch(() => ({}))) as Partial<T>;
+    if (!res.ok) this.logger(`  response body: ${JSON.stringify(body).slice(0, 300)}`);
     return { res, body };
   }
 
@@ -220,8 +263,8 @@ export class MunichTerminClient {
     return verify.token;
   }
 
-  /** Available days for a service. `days` is null on an unexpected error. */
-  async getAvailableDays(query: AvailableDaysQuery): Promise<AvailableDaysResult> {
+  /** Raw available-days call (no verification). `days` is null on an unexpected error. */
+  private async requestAvailableDays(query: AvailableDaysQuery): Promise<AvailableDaysResult> {
     const params = new URLSearchParams({
       officeId: String(query.officeId),
       serviceId: String(query.serviceId),
@@ -238,20 +281,28 @@ export class MunichTerminClient {
 
     const errors = body.errors ?? [];
     const errorCodes = errors.map((e) => e.errorCode);
-    // 404 + noAppointmentForThisScope is the API's normal "nothing free" answer.
-    if (res.status === 404 || errorCodes.includes("noAppointmentForThisScope")) return { days: [] };
+    // 404 / noAppointmentForThis* is the API's normal "nothing free" answer.
+    if (
+      res.status === 404 ||
+      errorCodes.includes("noAppointmentForThisScope") ||
+      errorCodes.includes("noAppointmentForThisDay")
+    ) {
+      return { days: [] };
+    }
 
     return { days: null, status: res.status, errors, errorCodes };
   }
 
-  /** Like getAvailableDays, but transparently solves the captcha when required. */
-  async availableDaysAuto(query: AvailableDaysQuery): Promise<AvailableDaysResult> {
-    let result = await this.getAvailableDays(query);
-    if (result.days === null && result.errorCodes?.includes("captchaMissing")) {
-      this.log("captcha required — solving…");
-      const captchaToken = await this.solveCaptcha();
-      result = await this.getAvailableDays({ ...query, captchaToken });
-    }
-    return result;
+  /**
+   * Available days for a service, run through the injected middleware chain
+   * (Altcha verification by default, applied only when the service requires it).
+   */
+  async availableDays(query: AvailableDaysQuery): Promise<AvailableDaysResult> {
+    const core: AvailabilityHandler = (q) => this.requestAvailableDays(q);
+    const handler = this.middlewares.reduceRight<AvailabilityHandler>(
+      (next, middleware) => (q) => middleware.handle(q, next),
+      core,
+    );
+    return handler(query);
   }
 }

--- a/libs/middleware.test.ts
+++ b/libs/middleware.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import type { AvailableDaysQuery, AvailableDaysResult } from "./client";
+import { altchaCaptchaMiddleware } from "./middleware";
+
+const query: AvailableDaysQuery = {
+  officeId: 10461,
+  serviceId: 10339028,
+  startDate: "2026-06-01",
+  endDate: "2026-09-01",
+};
+
+describe("altchaCaptchaMiddleware", () => {
+  it("passes through when days are returned (no captcha needed)", async () => {
+    let solves = 0;
+    const mw = altchaCaptchaMiddleware(async () => {
+      solves++;
+      return "tok";
+    });
+    const result = await mw.handle(query, async () => ({ days: ["2026-06-10"] }));
+    expect(result.days).toEqual(["2026-06-10"]);
+    expect(solves).toBe(0);
+  });
+
+  it("does not solve for non-captcha errors", async () => {
+    let solves = 0;
+    const mw = altchaCaptchaMiddleware(async () => {
+      solves++;
+      return "tok";
+    });
+    const result = await mw.handle(query, async () => ({
+      days: null,
+      status: 500,
+      errorCodes: ["serverError"],
+    }));
+    expect(result.days).toBeNull();
+    expect(solves).toBe(0);
+  });
+
+  it("solves and retries once on captchaMissing", async () => {
+    const tokens: (string | null | undefined)[] = [];
+    const next = async (q: AvailableDaysQuery): Promise<AvailableDaysResult> => {
+      tokens.push(q.captchaToken);
+      return tokens.length === 1
+        ? { days: null, status: 400, errorCodes: ["captchaMissing"] }
+        : { days: ["2026-08-08"] };
+    };
+    const mw = altchaCaptchaMiddleware(async () => "TOKEN");
+    const result = await mw.handle(query, next);
+    expect(tokens).toEqual([undefined, "TOKEN"]);
+    expect(result.days).toEqual(["2026-08-08"]);
+  });
+});

--- a/libs/middleware.ts
+++ b/libs/middleware.ts
@@ -1,0 +1,44 @@
+/*
+ * Availability-request middleware.
+ *
+ * A middleware wraps each `available-days` request and may inspect the result,
+ * adjust the query, and retry — exactly how the Altcha bot-verification is
+ * injected into the client without polluting the core request path.
+ */
+
+import type { AvailableDaysQuery, AvailableDaysResult } from "./client";
+
+/** Performs (or forwards) an availability request. */
+export type AvailabilityHandler = (query: AvailableDaysQuery) => Promise<AvailableDaysResult>;
+
+/** Wraps an availability request; calls `next` to continue the chain. */
+export interface AvailabilityMiddleware {
+  readonly name: string;
+  handle(query: AvailableDaysQuery, next: AvailabilityHandler): Promise<AvailableDaysResult>;
+}
+
+/**
+ * Injectable Altcha verification. It activates only for the services that
+ * actually demand a captcha — i.e. when the API answers `captchaMissing` — then
+ * solves the proof-of-work, injects the token, and retries the request once.
+ */
+export function altchaCaptchaMiddleware(
+  solveCaptcha: () => Promise<string>,
+  log: (...args: unknown[]) => void = () => {},
+): AvailabilityMiddleware {
+  return {
+    name: "altcha-captcha",
+    async handle(query, next) {
+      const result = await next(query);
+
+      const needsVerification =
+        result.days === null && (result.errorCodes?.includes("captchaMissing") ?? false);
+      if (!needsVerification) return result;
+
+      log(`[altcha] service ${query.serviceId} requires verification — solving captcha…`);
+      const captchaToken = await solveCaptcha();
+      log(`[altcha] verification solved — retrying request with token`);
+      return next({ ...query, captchaToken });
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "bun apps/check.ts",
     "find": "bun apps/find-service.ts",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",


### PR DESCRIPTION
Branched fresh off `main` (which already has the www48 captcha fix + immigration-only `*/5` schedule from #7). This adds the structural follow-ups:

## Altcha verification as injected middleware
- **`libs/middleware.ts`** — `AvailabilityMiddleware` interface + `altchaCaptchaMiddleware(solve, log)`, **injected** into the client (`ClientOptions.middlewares`, defaults to Altcha). It activates **only when a service answers `captchaMissing`**, solves the PoW, injects the token, and retries once.
- The core request path no longer knows about captchas: `availableDays()` runs the injected chain; the raw call is now private `requestAvailableDays()`. Disable with `new MunichTerminClient({ middlewares: [] })`.

## Detailed per-call logging
Every API call logs method, URL, status, timing, and error body via an **injectable logger** (`logger: () => {}` to silence). The `captchaToken` is redacted.

## Tests + quality pipeline
- **11 `bun test` tests** (no network — fetch stubbed): `libs/catalog.test.ts`, `libs/middleware.test.ts`, `libs/client.test.ts` (parsing, the full captcha solve→verify→retry flow, and token redaction).
- `ci.yml` now runs `oxfmt --check` → `tsc` → **`bun test`** on non-main branches/PRs; added a `test` script.

## Docs
README: layout table (`libs/middleware.ts`, `libs/*.test.ts`), the injected-middleware captcha section, and the per-call logging / `bun test` in Develop.

Verified locally: oxfmt clean, tsc clean, 11/11 tests pass; immigration check traced end-to-end against the live API.

https://claude.ai/code/session_011BosqCRq9t2vXg4irxjco6

---
_Generated by [Claude Code](https://claude.ai/code/session_011BosqCRq9t2vXg4irxjco6)_