### PR TITLE
Add Verpflichtungserklärung service to appointment availability checker

### DIFF
--- a/.github/workflows/verify-appointment-available.yml
+++ b/.github/workflows/verify-appointment-available.yml
@@ -18,6 +18,7 @@ on:
           - führerschein
           - einbürgerung
           - aufenthaltstitel
+          - verpflichtungserklärung
 
 # Avoid overlapping scheduled runs.
 concurrency:
@@ -26,7 +27,7 @@ concurrency:
 
 jobs:
   # Build the matrix from watchlist.ts. Manual runs may filter to one service;
-  # scheduled runs always check the whole watch-list.
+  # scheduled runs always check the Verpflichtungserklärung (Schnellschalter) service.
   config:
     runs-on: ubuntu-latest
     outputs:
@@ -46,8 +47,8 @@ jobs:
             echo "::error::Manual runs require a service selection." >&2
             exit 1
           fi
-          # Scheduled runs check only the immigration service; manual runs use the dropdown.
-          FILTER="${INPUT_SERVICE:-aufenthaltstitel}"
+          # Scheduled runs check only the Verpflichtungserklärung service; manual runs use the dropdown.
+          FILTER="${INPUT_SERVICE:-verpflichtungserklärung}"
           echo "matrix=$(bun apps/matrix.ts "$FILTER")" >> "$GITHUB_OUTPUT"
 
   check:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ notifies you when a slot opens up — Führerschein, Einbürgerung, immigration
 
 Munich uses the Berlin **ZMS ("Bürgeransicht")** system. This project queries its
 JSON API directly with a small, strictly-typed [Bun](https://bun.sh) client — no
-browser, no scraping. The scheduled GitHub Action checks the **immigration
-service** (_Notfall-Hilfe Aufenthaltstitel_) every 5 minutes; use the manual
-**Run workflow** dropdown to check Führerschein, Einbürgerung, or all of
+browser, no scraping. The scheduled GitHub Action checks the
+**Verpflichtungserklärung** service (_Schnellschalter_, Ruppertstraße 19) every
+5 minutes; use the manual **Run workflow** dropdown to check Führerschein,
+Einbürgerung, immigration (Aufenthaltstitel), or all of
 [`watchlist.ts`](./libs/watchlist.ts).
 
 ## Layout

--- a/libs/watchlist.ts
+++ b/libs/watchlist.ts
@@ -36,4 +36,5 @@ export const WATCHLIST = [
     officeId: 10461,
     captcha: true,
   },
+  { name: "Verpflichtungserklärung abgeben", serviceId: 1063741, officeId: 10308621 },
 ] as const satisfies readonly WatchEntry[];


### PR DESCRIPTION
## Summary
This PR adds support for monitoring the Verpflichtungserklärung (declaration of commitment) service in the appointment availability checker. The service is now included in the watchlist and set as the default service for scheduled GitHub Action runs.

## Key Changes
- Added `verpflichtungserklärung` to the workflow trigger list in the manual run dropdown
- Added Verpflichtungserklärung service entry to `watchlist.ts` with service ID 1063741 and office ID 10308621
- Updated the default service for scheduled runs from `aufenthaltstitel` (immigration) to `verpflichtungserklärung`
- Updated documentation in README.md to reflect that scheduled runs now check the Verpflichtungserklärung service (_Schnellschalter_, Ruppertstraße 19) every 5 minutes
- Updated workflow comments to clarify the new default behavior

## Implementation Details
The Verpflichtungserklärung service is now the primary service monitored by the scheduled GitHub Action (running every 5 minutes), while users can still manually check other services (Führerschein, Einbürgerung, Aufenthaltstitel) via the workflow dropdown.

https://claude.ai/code/session_01FNegyNgnpXXd4xW9oAGpYV